### PR TITLE
 Add proximity_state sysfs support to goodix driver

### DIFF
--- a/drivers/input/fingerprint/goodix/gf_spi.c
+++ b/drivers/input/fingerprint/goodix/gf_spi.c
@@ -641,6 +641,37 @@ static const struct file_operations gf_fops = {
 #endif
 };
 
+static ssize_t proximity_state_set(struct device *dev,
+	struct device_attribute *attr, const char *buf, size_t count)
+{
+	struct gf_dev *gf_dev = dev_get_drvdata(dev);
+	int rc, val;
+
+	rc = kstrtoint(buf, 10, &val);
+	if (rc)
+		return -EINVAL;
+
+	gf_dev->proximity_state = !!val;
+
+	if (gf_dev->proximity_state) {
+		gf_disable_irq(gf_dev);
+	} else {
+		gf_enable_irq(gf_dev);
+	}
+
+	return count;
+}
+
+static DEVICE_ATTR(proximity_state, S_IWUSR, NULL, proximity_state_set);
+
+static struct attribute *attributes[] = {
+	&dev_attr_proximity_state.attr,
+	NULL
+};
+
+static const struct attribute_group attribute_group = {
+	.attrs = attributes,
+};
 
 #if defined(CONFIG_FB)
 static int goodix_fb_state_chg_callback(struct notifier_block *nb,
@@ -763,6 +794,7 @@ static int gf_probe(struct platform_device *pdev)
 #endif
 {
 	struct gf_dev *gf_dev = &gf;
+	struct device *dev = &pdev->dev;
 	int status = -EINVAL;
 	unsigned long minor;
 	int i;
@@ -871,6 +903,14 @@ static int gf_probe(struct platform_device *pdev)
 	if (status)
 		pr_err("Unable to register msm_drm_notifier: %d\n", status);
 #endif
+
+	dev_set_drvdata(dev, gf_dev);
+
+	status = sysfs_create_group(&dev->kobj, &attribute_group);
+	if (status) {
+		dev_err(dev, "could not create sysfs\n");
+		goto err_irq;
+	}
 
 	pr_info("version V%d.%d.%02d\n", VER_MAJOR, VER_MINOR, PATCH_LEVEL);
 

--- a/drivers/input/fingerprint/goodix/gf_spi.h
+++ b/drivers/input/fingerprint/goodix/gf_spi.h
@@ -160,6 +160,8 @@ struct gf_dev {
 	struct pinctrl_state   *gpio_state_disable;
 	signed enable_gpio;
 	int project_version;
+	struct notifier_block notifier;
+	int proximity_state; /* 0:far 1:near */
 };
 
 int gf_pinctrl_init(struct gf_dev* gf_dev);


### PR DESCRIPTION
*) Implements sysfs proximity_state so that fp reader
   can be disabled by PocketMode app.

*) Code fragments copied from fpc1020 driver where possible.